### PR TITLE
example: Add second, simpler example.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["egui-graph-edit", "egui-graph-edit-example"]
+members = ["egui-graph-edit", "egui-graph-edit-example", "egui-graph-edit-example-simple"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ clicking anywhere on the screen will bring up the *node finder* menu.
 
 The [application code in the example](https://github.com/kamirr/egui-graph-edit/blob/main/egui-graph-edit-example/src/app.rs)
 is thoroughly commented and serves as a good introduction to embedding this
-library in your egui project.
+library in your egui project. There is additional, [simpler example](https://github.com/kamirr/egui-graph-edit/blob/main/egui-graph-edit-example-simple/src/app.rs).
 
 ## A note on API visibility
 Contrary to the general tendency in the Rust ecosytem, this library exposes all

--- a/egui-graph-edit-example-simple/Cargo.toml
+++ b/egui-graph-edit-example-simple/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.30"
+eframe = "0.31"
 egui-graph-edit = { path = "../egui-graph-edit" }
 anyhow = "1.0"
 

--- a/egui-graph-edit-example-simple/Cargo.toml
+++ b/egui-graph-edit-example-simple/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "egui-graph-edit-example-simple"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.56"
+
+[dependencies]
+eframe = "0.30"
+egui-graph-edit = { path = "../egui-graph-edit" }
+anyhow = "1.0"
+
+[features]
+default = []

--- a/egui-graph-edit-example-simple/src/app.rs
+++ b/egui-graph-edit-example-simple/src/app.rs
@@ -208,12 +208,7 @@ impl NodeGraphExampleSimple {
 
         let mut out = String::with_capacity(128);
 
-        fn printer(
-            out: &mut String,
-            nid: NodeId,
-            graph: &egui_graph_edit::Graph<DummyNodeData, DummyDataType, DummyValueType>,
-            db: &BTreeMap<NodeId, NodeInfo>,
-        ) {
+        fn printer(out: &mut String, nid: NodeId, db: &BTreeMap<NodeId, NodeInfo>) {
             let info = db.get(&nid).unwrap();
             if info.printed.get() {
                 out.push_str("...");
@@ -222,7 +217,7 @@ impl NodeGraphExampleSimple {
             info.printed.set(true);
             out.push_str("(node ");
             for input in &info.ins {
-                printer(out, *input, graph, db);
+                printer(out, *input, db);
             }
             out.push_str(") ");
             info.printed.set(true);
@@ -232,7 +227,7 @@ impl NodeGraphExampleSimple {
             if !info.leaf {
                 continue;
             }
-            printer(&mut out, *id, &self.state.graph, &nodes);
+            printer(&mut out, *id, &nodes);
         }
 
         out

--- a/egui-graph-edit-example-simple/src/app.rs
+++ b/egui-graph-edit-example-simple/src/app.rs
@@ -3,23 +3,41 @@ use std::borrow::Cow;
 use eframe::egui;
 use egui_graph_edit::*;
 
+/// Additional (besides inputs and outputs) state to be stored inside each node.
 #[derive(Debug)]
 pub struct DummyNodeData;
 
+// Connection variant. Equal DataType means input port is compatible with output port.
+// Typically an enum, but this example has only one connection type (any output can be connected to any input),
+// so this type is dummied out.
 #[derive(PartialEq, Eq, Debug)]
 pub struct DummyDataType;
 
+/// Type of the editable value that is used as a fallback for unconnected input node,
+/// i.e. when some input to a node can be either constant or taken from another node,
+/// this defines how to store that constant.
+///
+/// This example does not feature editable content within nodes, so this type is dummy.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct DummyValueType;
 
+/// Typically an enum that lists node types.
+/// In this example there is only one node type ("Node"),
+/// so no this type is dummy.
 #[derive(Clone, Copy)]
 pub struct DummyNodeTemplate;
 
+/// Additional events that bubble up from `NodeDataTrait::bottom_ui` back to your app.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DummyResponse;
 
+/// Supplementary, user-defined whole-graph state (i.e. a designated node)
+/// Per-node supplemental infromation is stored elsewhere, not here.
+///
+/// This example does not use such state, so this type is dummied out.
 type DummyGraphState = ();
 
+/// Defines how to render edges (connections) between nodes
 impl DataTypeTrait<DummyGraphState> for DummyDataType {
     fn data_type_color(&self, _user_state: &mut DummyGraphState) -> egui::Color32 {
         egui::Color32::from_rgb(238, 207, 60)
@@ -30,6 +48,8 @@ impl DataTypeTrait<DummyGraphState> for DummyDataType {
     }
 }
 
+/// Defines how to name and construct each node variant and what inputs and
+/// outputs each node variant has.
 impl NodeTemplateTrait for DummyNodeTemplate {
     type NodeData = DummyNodeData;
     type DataType = DummyDataType;
@@ -41,10 +61,8 @@ impl NodeTemplateTrait for DummyNodeTemplate {
         "Node".into()
     }
 
-    fn node_graph_label(&self, user_state: &mut Self::UserState) -> String {
-        // It's okay to delegate this to node_finder_label if you don't want to
-        // show different names in the node finder and the node itself.
-        self.node_finder_label(user_state).into()
+    fn node_graph_label(&self, _user_state: &mut Self::UserState) -> String {
+        "Node".to_owned()
     }
 
     fn user_data(&self, _user_state: &mut Self::UserState) -> Self::NodeData {
@@ -77,6 +95,7 @@ impl NodeTemplateTrait for DummyNodeTemplate {
     }
 }
 
+/// Enumeration of all node variants to populate the context menu that allows creating nodes
 pub struct AllMyNodeTemplates;
 impl NodeTemplateIter for AllMyNodeTemplates {
     type Item = DummyNodeTemplate;
@@ -86,6 +105,7 @@ impl NodeTemplateIter for AllMyNodeTemplates {
     }
 }
 
+/// Defines how to render input's GUI when it is not connected.
 impl WidgetValueTrait for DummyValueType {
     type Response = DummyResponse;
     type UserState = DummyGraphState;
@@ -104,6 +124,8 @@ impl WidgetValueTrait for DummyValueType {
 }
 
 impl UserResponseTrait for DummyResponse {}
+
+/// Defines how to render node window (besides inputs and output ports)
 impl NodeDataTrait for DummyNodeData {
     type Response = DummyResponse;
     type UserState = DummyGraphState;
@@ -124,6 +146,7 @@ impl NodeDataTrait for DummyNodeData {
     }
 }
 
+/// Main graph editor type
 type MyEditorState = GraphEditorState<
     DummyNodeData,
     DummyDataType,
@@ -136,39 +159,54 @@ type MyEditorState = GraphEditorState<
 pub struct NodeGraphExampleSimple {
     state: MyEditorState,
     user_state: DummyGraphState,
+    /// Text to display above the graph
     cached_text_graph_description: String,
 }
 
 impl eframe::App for NodeGraphExampleSimple {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // Add a panel with buttons
         egui::TopBottomPanel::top("top").show(ctx, |ui| {
             egui::menu::bar(ui, |ui| {
                 egui::widgets::global_theme_preference_switch(ui);
                 if ui.button("Create a node").clicked() {
+                    // Add a node to the database inside egui-graph-edit.
                     let id =
                         self.state
                             .graph
                             .add_node("Node".to_owned(), DummyNodeData, |_g, _id| {});
+                    // Supplement z-order for the node (panic if missing)
                     self.state.node_order.push(id);
+                    // Position the node within editor area ((panic if missing)
                     self.state
                         .node_positions
                         .insert(id, egui::Pos2 { x: 20.0, y: 20.0 });
+                    // Fill in GUI within the node window, create inputs and outputs
                     DummyNodeTemplate.build_node(&mut self.state.graph, &mut self.user_state, id);
+                    // Recalculate the line to display above the graph
                     self.cached_text_graph_description = self.calculate_result();
                 }
             });
         });
+        // Add a panel where textual representation of the graph will be displayed
         egui::TopBottomPanel::top("result").show(ctx, |ui| {
             ui.label(&self.cached_text_graph_description);
         });
 
+        // Add main panel with the interactive graph
         egui::CentralPanel::default().show(ctx, |ui| {
+            // Triger graph display and obtain user interaction events, if any.
             let ret = self.state.draw_graph_editor(
                 ui,
                 AllMyNodeTemplates,
                 &mut self.user_state,
                 Vec::default(),
             );
+            // On any significant user interaction (i.e. creating or removing a node,
+            // adding or removing an edge) recalculate the line.
+            //
+            // Insignificant interactions (like dragging things around)
+            // are not included in `node_responses`
             if !ret.node_responses.is_empty() {
                 self.cached_text_graph_description = self.calculate_result();
             }
@@ -177,13 +215,19 @@ impl eframe::App for NodeGraphExampleSimple {
 }
 
 impl NodeGraphExampleSimple {
+    /// Walk the graph and calculate an S-expression that is shaped like the graph
     fn calculate_result(&self) -> String {
+        // BTreeMap instead of HashMap to avoid chaotic reorderings within the resulting text
         use std::collections::BTreeMap;
+        // Information about node position within hierarchy.
         struct NodeInfo {
             ins: Vec<NodeId>,
             leaf: bool,
+            /// Replace this node with "..." when printing,
+            /// as it was already printed before; prevent endless recursion.
             printed: std::cell::Cell<bool>,
         }
+        // Initial filling of the node table
         let mut nodes: BTreeMap<NodeId, NodeInfo> = self
             .state
             .graph
@@ -199,15 +243,20 @@ impl NodeGraphExampleSimple {
                 )
             })
             .collect();
+        // Adding inner (i.e. parent) node pointers
         for (input_id, output_id) in self.state.graph.iter_connections() {
+            // lookup information about connection details
+            // (in our case, from where to where it is going)
             let input = self.state.graph.inputs.get(input_id).unwrap();
             let output = self.state.graph.outputs.get(output_id).unwrap();
             nodes.get_mut(&input.node).unwrap().ins.push(output.node);
             nodes.get_mut(&output.node).unwrap().leaf = false;
         }
 
+        // Output buffer
         let mut out = String::with_capacity(128);
 
+        // Recursive function to output the S-expression
         fn printer(out: &mut String, nid: NodeId, db: &BTreeMap<NodeId, NodeInfo>) {
             let info = db.get(&nid).unwrap();
             if info.printed.get() {
@@ -223,6 +272,7 @@ impl NodeGraphExampleSimple {
             info.printed.set(true);
         }
 
+        // Iterate leaf nodes and print them
         for (id, info) in nodes.iter() {
             if !info.leaf {
                 continue;

--- a/egui-graph-edit-example-simple/src/app.rs
+++ b/egui-graph-edit-example-simple/src/app.rs
@@ -1,0 +1,240 @@
+use std::borrow::Cow;
+
+use eframe::egui;
+use egui_graph_edit::*;
+
+#[derive(Debug)]
+pub struct DummyNodeData;
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct DummyDataType;
+
+#[derive(Copy, Clone, Debug, Default)]
+pub struct DummyValueType;
+
+#[derive(Clone, Copy)]
+pub struct DummyNodeTemplate;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DummyResponse;
+
+type DummyGraphState = ();
+
+impl DataTypeTrait<DummyGraphState> for DummyDataType {
+    fn data_type_color(&self, _user_state: &mut DummyGraphState) -> egui::Color32 {
+        egui::Color32::from_rgb(238, 207, 60)
+    }
+
+    fn name(&self) -> Cow<'_, str> {
+        "edge".into()
+    }
+}
+
+impl NodeTemplateTrait for DummyNodeTemplate {
+    type NodeData = DummyNodeData;
+    type DataType = DummyDataType;
+    type ValueType = DummyValueType;
+    type UserState = DummyGraphState;
+    type CategoryType = &'static str;
+
+    fn node_finder_label(&self, _user_state: &mut Self::UserState) -> Cow<'_, str> {
+        "Node".into()
+    }
+
+    fn node_graph_label(&self, user_state: &mut Self::UserState) -> String {
+        // It's okay to delegate this to node_finder_label if you don't want to
+        // show different names in the node finder and the node itself.
+        self.node_finder_label(user_state).into()
+    }
+
+    fn user_data(&self, _user_state: &mut Self::UserState) -> Self::NodeData {
+        DummyNodeData
+    }
+
+    fn build_node(
+        &self,
+        graph: &mut Graph<Self::NodeData, Self::DataType, Self::ValueType>,
+        _user_state: &mut Self::UserState,
+        node_id: NodeId,
+    ) {
+        graph.add_input_param(
+            node_id,
+            "in1".to_owned(),
+            DummyDataType,
+            DummyValueType,
+            InputParamKind::ConnectionOnly,
+            true,
+        );
+        graph.add_input_param(
+            node_id,
+            "in2".to_string(),
+            DummyDataType,
+            DummyValueType,
+            InputParamKind::ConnectionOnly,
+            true,
+        );
+        graph.add_output_param(node_id, "out".to_string(), DummyDataType);
+    }
+}
+
+pub struct AllMyNodeTemplates;
+impl NodeTemplateIter for AllMyNodeTemplates {
+    type Item = DummyNodeTemplate;
+
+    fn all_kinds(&self) -> Vec<Self::Item> {
+        vec![DummyNodeTemplate]
+    }
+}
+
+impl WidgetValueTrait for DummyValueType {
+    type Response = DummyResponse;
+    type UserState = DummyGraphState;
+    type NodeData = DummyNodeData;
+    fn value_widget(
+        &mut self,
+        _param_name: &str,
+        _node_id: NodeId,
+        ui: &mut egui::Ui,
+        _user_state: &mut DummyGraphState,
+        _node_data: &DummyNodeData,
+    ) -> Vec<DummyResponse> {
+        ui.label("x");
+        Vec::new()
+    }
+}
+
+impl UserResponseTrait for DummyResponse {}
+impl NodeDataTrait for DummyNodeData {
+    type Response = DummyResponse;
+    type UserState = DummyGraphState;
+    type DataType = DummyDataType;
+    type ValueType = DummyValueType;
+
+    fn bottom_ui(
+        &self,
+        _ui: &mut egui::Ui,
+        _node_id: NodeId,
+        _graph: &Graph<DummyNodeData, DummyDataType, DummyValueType>,
+        _user_state: &mut Self::UserState,
+    ) -> Vec<NodeResponse<DummyResponse, DummyNodeData>>
+    where
+        DummyResponse: UserResponseTrait,
+    {
+        vec![]
+    }
+}
+
+type MyEditorState = GraphEditorState<
+    DummyNodeData,
+    DummyDataType,
+    DummyValueType,
+    DummyNodeTemplate,
+    DummyGraphState,
+>;
+
+#[derive(Default)]
+pub struct NodeGraphExampleSimple {
+    state: MyEditorState,
+    user_state: DummyGraphState,
+    cached_text_graph_description: String,
+}
+
+impl eframe::App for NodeGraphExampleSimple {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::TopBottomPanel::top("top").show(ctx, |ui| {
+            egui::menu::bar(ui, |ui| {
+                egui::widgets::global_theme_preference_switch(ui);
+                if ui.button("Create a node").clicked() {
+                    let id =
+                        self.state
+                            .graph
+                            .add_node("Node".to_owned(), DummyNodeData, |_g, _id| {});
+                    self.state.node_order.push(id);
+                    self.state
+                        .node_positions
+                        .insert(id, egui::Pos2 { x: 20.0, y: 20.0 });
+                    DummyNodeTemplate.build_node(&mut self.state.graph, &mut self.user_state, id);
+                    self.cached_text_graph_description = self.calculate_result();
+                }
+            });
+        });
+        egui::TopBottomPanel::top("result").show(ctx, |ui| {
+            ui.label(&self.cached_text_graph_description);
+        });
+
+        egui::CentralPanel::default().show(ctx, |ui| {
+            let ret = self.state.draw_graph_editor(
+                ui,
+                AllMyNodeTemplates,
+                &mut self.user_state,
+                Vec::default(),
+            );
+            if !ret.node_responses.is_empty() {
+                self.cached_text_graph_description = self.calculate_result();
+            }
+        });
+    }
+}
+
+impl NodeGraphExampleSimple {
+    fn calculate_result(&self) -> String {
+        use std::collections::BTreeMap;
+        struct NodeInfo {
+            ins: Vec<NodeId>,
+            leaf: bool,
+            printed: std::cell::Cell<bool>,
+        }
+        let mut nodes: BTreeMap<NodeId, NodeInfo> = self
+            .state
+            .graph
+            .iter_nodes()
+            .map(|x| {
+                (
+                    x,
+                    NodeInfo {
+                        ins: vec![],
+                        leaf: true,
+                        printed: false.into(),
+                    },
+                )
+            })
+            .collect();
+        for (input_id, output_id) in self.state.graph.iter_connections() {
+            let input = self.state.graph.inputs.get(input_id).unwrap();
+            let output = self.state.graph.outputs.get(output_id).unwrap();
+            nodes.get_mut(&input.node).unwrap().ins.push(output.node);
+            nodes.get_mut(&output.node).unwrap().leaf = false;
+        }
+
+        let mut out = String::with_capacity(128);
+
+        fn printer(
+            out: &mut String,
+            nid: NodeId,
+            graph: &egui_graph_edit::Graph<DummyNodeData, DummyDataType, DummyValueType>,
+            db: &BTreeMap<NodeId, NodeInfo>,
+        ) {
+            let info = db.get(&nid).unwrap();
+            if info.printed.get() {
+                out.push_str("...");
+                return;
+            }
+            info.printed.set(true);
+            out.push_str("(node ");
+            for input in &info.ins {
+                printer(out, *input, graph, db);
+            }
+            out.push_str(") ");
+            info.printed.set(true);
+        }
+
+        for (id, info) in nodes.iter() {
+            if !info.leaf {
+                continue;
+            }
+            printer(&mut out, *id, &self.state.graph, &nodes);
+        }
+
+        out
+    }
+}

--- a/egui-graph-edit-example-simple/src/main.rs
+++ b/egui-graph-edit-example-simple/src/main.rs
@@ -10,11 +10,7 @@ fn main() {
     eframe::run_native(
         "Egui Graph Edit simple example",
         eframe::NativeOptions::default(),
-        Box::new(|_cc| {
-            Ok({
-                Box::<NodeGraphExampleSimple>::default()
-            })
-        }),
+        Box::new(|_cc| Ok(Box::<NodeGraphExampleSimple>::default())),
     )
     .expect("Failed to run native example");
 }

--- a/egui-graph-edit-example-simple/src/main.rs
+++ b/egui-graph-edit-example-simple/src/main.rs
@@ -7,6 +7,7 @@ mod app;
 use app::NodeGraphExampleSimple;
 
 fn main() {
+    // egui native app boilerplate:
     eframe::run_native(
         "Egui Graph Edit simple example",
         eframe::NativeOptions::default(),

--- a/egui-graph-edit-example-simple/src/main.rs
+++ b/egui-graph-edit-example-simple/src/main.rs
@@ -1,0 +1,20 @@
+#![forbid(unsafe_code)]
+#![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
+#![warn(clippy::all, rust_2018_idioms)]
+
+mod app;
+
+use app::NodeGraphExampleSimple;
+
+fn main() {
+    eframe::run_native(
+        "Egui Graph Edit simple example",
+        eframe::NativeOptions::default(),
+        Box::new(|_cc| {
+            Ok({
+                Box::<NodeGraphExampleSimple>::default()
+            })
+        }),
+    )
+    .expect("Failed to run native example");
+}


### PR DESCRIPTION
There is already "egui-graph-edit-example", but it may be too big and overwhelming to start from.

Here is an alternative example that may serve as a better starting point for learning egui-graph-edit and maybe a better template to integrate it into another project in some cases.

* Most user-definable types are dummies. Nodes and edges do not carry any payload. There is only one node type.
* Persistence is removed.
* Web support is removed.
* The example showcases how to extract graph structure from `state.graph`.
* The example also demonstrates how to add a node from out outside (without using a built-in node creation menu).

I expect removed features should be relatively straightforward to re-add by looking at the main example.