### PR TITLE
Bump egui version and crate version as well.

### DIFF
--- a/egui-graph-edit-example-simple/Cargo.toml
+++ b/egui-graph-edit-example-simple/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.32"
+eframe = "0.33"
 egui-graph-edit = { path = "../egui-graph-edit" }
 anyhow = "1.0"
 

--- a/egui-graph-edit-example/Cargo.toml
+++ b/egui-graph-edit-example/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "1.0"
-eframe = "0.32"
+eframe = "0.33"
 egui-graph-edit = { path = "../egui-graph-edit" }
 serde = { version = "1.0", optional = true }
 

--- a/egui-graph-edit/Cargo.toml
+++ b/egui-graph-edit/Cargo.toml
@@ -8,14 +8,14 @@ license = "MIT"
 name = "egui-graph-edit"
 readme = "../README.md"
 repository = "https://github.com/kamirr/egui-graph-edit"
-version = "0.7.1"
+version = "0.7.2"
 workspace = ".."
 
 [features]
 persistence = ["serde", "slotmap/serde", "smallvec/serde", "egui/persistence"]
 
 [dependencies]
-egui = { version = "0.32" }
+egui = { version = "0.33" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 slotmap = { version = "1.0" }
 smallvec = { version = "1.11.2" }

--- a/egui-graph-edit/src/node_finder.rs
+++ b/egui-graph-edit/src/node_finder.rs
@@ -68,7 +68,7 @@ where
 
                 let mut query_submit = resp.lost_focus() && ui.input(|i| i.key_pressed(Key::Enter));
 
-                let max_height = ui.input(|i| i.screen_rect.height() * 0.5);
+                let max_height = ui.input(|i| i.content_rect().height() * 0.5);
                 let scroll_area_width = resp.rect.width() - 30.0;
 
                 let all_kinds = all_kinds.all_kinds();

--- a/egui-graph-edit/src/traits.rs
+++ b/egui-graph-edit/src/traits.rs
@@ -84,7 +84,7 @@ pub trait DataTypeTrait<UserState>: PartialEq + Eq {
     ///     }
     /// }
     /// ```
-    fn name(&self) -> std::borrow::Cow<str>;
+    fn name(&self) -> std::borrow::Cow<'_, str>;
 }
 
 /// This trait must be implemented for the `NodeData` generic parameter of the
@@ -260,7 +260,7 @@ pub trait NodeTemplateTrait: Clone {
     /// The return type is Cow<str> to allow returning owned or borrowed values
     /// more flexibly. Refer to the documentation for `DataTypeTrait::name` for
     /// more information
-    fn node_finder_label(&self, user_state: &mut Self::UserState) -> std::borrow::Cow<str>;
+    fn node_finder_label(&self, user_state: &mut Self::UserState) -> std::borrow::Cow<'_, str>;
 
     /// Vec of categories to which the node belongs.
     ///


### PR DESCRIPTION
Fixes #17 by upgrading to egui 0.33. I wasn't sure the decorum on whether upgrading egui called for updating this crate's version. Since it is technically a breaking change I went ahead and did so, but since it's somewhat minor I only updated the patch number.