### PR TITLE
Update egui to 0.34

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,7 @@
 [workspace]
-members = ["egui-graph-edit", "egui-graph-edit-example", "egui-graph-edit-example-simple"]
+resolver = "3"
+members = [
+    "egui-graph-edit",
+    "egui-graph-edit-example",
+    "egui-graph-edit-example-simple",
+]

--- a/egui-graph-edit-example-simple/Cargo.toml
+++ b/egui-graph-edit-example-simple/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-eframe = "0.33"
+eframe = "0.34"
 egui-graph-edit = { path = "../egui-graph-edit" }
 anyhow = "1.0"
 

--- a/egui-graph-edit-example-simple/src/app.rs
+++ b/egui-graph-edit-example-simple/src/app.rs
@@ -164,9 +164,9 @@ pub struct NodeGraphExampleSimple {
 }
 
 impl eframe::App for NodeGraphExampleSimple {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         // Add a panel with buttons
-        egui::TopBottomPanel::top("top").show(ctx, |ui| {
+        egui::Panel::top("top").show_inside(ui, |ui| {
             egui::MenuBar::new().ui(ui, |ui| {
                 egui::widgets::global_theme_preference_switch(ui);
                 if ui.button("Create a node").clicked() {
@@ -193,12 +193,12 @@ impl eframe::App for NodeGraphExampleSimple {
             });
         });
         // Add a panel where textual representation of the graph will be displayed
-        egui::TopBottomPanel::top("result").show(ctx, |ui| {
+        egui::Panel::top("result").show_inside(ui, |ui| {
             ui.label(&self.cached_text_graph_description);
         });
 
         // Add main panel with the interactive graph
-        egui::CentralPanel::default().show(ctx, |ui| {
+        egui::CentralPanel::default().show_inside(ui, |ui| {
             // Triger graph display and obtain user interaction events, if any.
             let ret = self.state.draw_graph_editor(
                 ui,

--- a/egui-graph-edit-example-simple/src/main.rs
+++ b/egui-graph-edit-example-simple/src/main.rs
@@ -11,7 +11,15 @@ fn main() {
     eframe::run_native(
         "Egui Graph Edit simple example",
         eframe::NativeOptions::default(),
-        Box::new(|_cc| Ok(Box::<NodeGraphExampleSimple>::default())),
+        Box::new(|cc| {
+            // Graph node IDs are not stable when the render order changes
+            #[cfg(debug_assertions)]
+            cc.egui_ctx.all_styles_mut(|s| {
+                s.debug.warn_if_rect_changes_id = false;
+            });
+
+            Ok(Box::<NodeGraphExampleSimple>::default())
+        }),
     )
     .expect("Failed to run native example");
 }

--- a/egui-graph-edit-example/Cargo.toml
+++ b/egui-graph-edit-example/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "1.0"
-eframe = "0.33"
+eframe = "0.34"
 egui-graph-edit = { path = "../egui-graph-edit" }
 serde = { version = "1.0", optional = true }
 

--- a/egui-graph-edit-example/Cargo.toml
+++ b/egui-graph-edit-example/Cargo.toml
@@ -17,6 +17,3 @@ serde = { version = "1.0", optional = true }
 [features]
 default = []
 persistence = ["serde", "egui-graph-edit/persistence", "eframe/persistence"]
-
-[profile.release]
-opt-level = 2 # fast and small wasm

--- a/egui-graph-edit-example/src/app.rs
+++ b/egui-graph-edit-example/src/app.rs
@@ -407,16 +407,17 @@ impl eframe::App for NodeGraphExample {
     fn save(&mut self, storage: &mut dyn eframe::Storage) {
         eframe::set_value(storage, PERSISTENCE_KEY, &self.state);
     }
+
     /// Called each time the UI needs repainting, which may be many times per second.
     /// Put your widgets into a `SidePanel`, `TopPanel`, `CentralPanel`, `Window` or `Area`.
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        egui::TopBottomPanel::top("top").show(ctx, |ui| {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        egui::Panel::top("top").show_inside(ui, |ui| {
             egui::MenuBar::new().ui(ui, |ui| {
                 egui::widgets::global_theme_preference_switch(ui);
             });
         });
         let graph_response = egui::CentralPanel::default()
-            .show(ctx, |ui| {
+            .show_inside(ui, |ui| {
                 self.state.draw_graph_editor(
                     ui,
                     AllMyNodeTemplates,
@@ -443,11 +444,11 @@ impl eframe::App for NodeGraphExample {
                     Ok(value) => format!("The result is: {:?}", value),
                     Err(err) => format!("Execution error: {}", err),
                 };
-                ctx.debug_painter().text(
+                ui.debug_painter().text(
                     egui::pos2(10.0, 35.0),
                     egui::Align2::LEFT_TOP,
                     text,
-                    TextStyle::Button.resolve(&ctx.style()),
+                    TextStyle::Button.resolve(&ui.style()),
                     egui::Color32::WHITE,
                 );
             } else {

--- a/egui-graph-edit-example/src/app.rs
+++ b/egui-graph-edit-example/src/app.rs
@@ -448,7 +448,7 @@ impl eframe::App for NodeGraphExample {
                     egui::pos2(10.0, 35.0),
                     egui::Align2::LEFT_TOP,
                     text,
-                    TextStyle::Button.resolve(&ui.style()),
+                    TextStyle::Button.resolve(ui.style()),
                     egui::Color32::WHITE,
                 );
             } else {

--- a/egui-graph-edit-example/src/main.rs
+++ b/egui-graph-edit-example/src/main.rs
@@ -15,6 +15,13 @@ fn main() {
         Box::new(|cc| {
             Ok({
                 cc.egui_ctx.set_visuals(Visuals::dark());
+
+                // Graph node IDs are not stable when the render order changes
+                #[cfg(debug_assertions)]
+                cc.egui_ctx.all_styles_mut(|s| {
+                    s.debug.warn_if_rect_changes_id = false;
+                });
+
                 #[cfg(feature = "persistence")]
                 {
                     Box::new(NodeGraphExample::new(cc))

--- a/egui-graph-edit/Cargo.toml
+++ b/egui-graph-edit/Cargo.toml
@@ -15,7 +15,7 @@ workspace = ".."
 persistence = ["serde", "slotmap/serde", "smallvec/serde", "egui/persistence"]
 
 [dependencies]
-egui = { version = "0.33" }
+egui = { version = "0.34" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 slotmap = { version = "1.0" }
 smallvec = { version = "1.11.2" }

--- a/egui-graph-edit/src/editor_ui.rs
+++ b/egui-graph-edit/src/editor_ui.rs
@@ -998,6 +998,7 @@ where
                 stroke_kind: StrokeKind::Inside,
                 round_to_pixels: None,
                 brush: None,
+                angle: 0.0,
             });
 
             let body_rect = Rect::from_min_size(
@@ -1013,6 +1014,7 @@ where
                 stroke_kind: StrokeKind::Inside,
                 round_to_pixels: None,
                 brush: None,
+                angle: 0.0,
             });
 
             let bottom_body_rect = Rect::from_min_size(
@@ -1028,6 +1030,7 @@ where
                 stroke_kind: StrokeKind::Inside,
                 round_to_pixels: None,
                 brush: None,
+                angle: 0.0,
             });
 
             let node_rect = titlebar_rect.union(body_rect).union(bottom_body_rect);
@@ -1041,6 +1044,7 @@ where
                     stroke_kind: StrokeKind::Inside,
                     round_to_pixels: None,
                     brush: None,
+                    angle: 0.0,
                 })
             } else {
                 Shape::Noop

--- a/egui-graph-edit/src/editor_ui.rs
+++ b/egui-graph-edit/src/editor_ui.rs
@@ -493,7 +493,7 @@ where
                 selection_rect,
                 2.0,
                 bg_color,
-                Stroke::new(3.0, stroke_color),
+                Stroke::new(3.0f32, stroke_color),
                 StrokeKind::Outside,
             );
 

--- a/egui-graph-edit/src/editor_ui.rs
+++ b/egui-graph-edit/src/editor_ui.rs
@@ -788,12 +788,13 @@ where
             for (param_name, param_id) in outputs {
                 let height_before = ui.min_rect().bottom();
                 ui.with_layout(output_layout, |ui| {
-                    responses.extend(
-                        self.graph[self.node_id]
-                            .user_data
-                            .output_ui(ui, self.node_id, self.graph, user_state, &param_name)
-                            .into_iter(),
-                    );
+                    responses.extend(self.graph[self.node_id].user_data.output_ui(
+                        ui,
+                        self.node_id,
+                        self.graph,
+                        user_state,
+                        &param_name,
+                    ));
                 });
 
                 self.graph[self.node_id].user_data.separator(
@@ -921,7 +922,7 @@ where
         for ((_, param), port_height) in self.graph[self.node_id]
             .inputs
             .iter()
-            .zip(input_port_heights.into_iter())
+            .zip(input_port_heights)
         {
             let should_draw = match self.graph[*param].kind() {
                 InputParamKind::ConnectionOnly => true,
@@ -954,7 +955,7 @@ where
         for ((_, param), port_height) in self.graph[self.node_id]
             .outputs
             .iter()
-            .zip(output_port_heights.into_iter())
+            .zip(output_port_heights)
         {
             let port_pos = match self.orientation {
                 NodeOrientation::LeftToRight => pos2(port_right, port_height),

--- a/egui-graph-edit/src/node_finder.rs
+++ b/egui-graph-edit/src/node_finder.rs
@@ -49,7 +49,7 @@ where
             text_color = color_from_hex("#3f3f3f").unwrap();
         }
 
-        ui.visuals_mut().widgets.noninteractive.fg_stroke = Stroke::new(2.0, text_color);
+        ui.visuals_mut().widgets.noninteractive.fg_stroke = Stroke::new(2.0f32, text_color);
 
         let frame = Frame::dark_canvas(ui.style())
             .fill(background_color)


### PR DESCRIPTION
- [x] clippy
- [x] selecting a new node in example causes some items inside the previous selected node to flash with a red rectangle.
  - Id stability issue, deemed to be low-priority
  - Spin off: https://github.com/kamirr/egui-graph-edit/issues/23.