### PR TITLE
feat: allow custom node border colors

### DIFF
--- a/egui-graph-edit/src/editor_ui.rs
+++ b/egui-graph-edit/src/editor_ui.rs
@@ -1035,12 +1035,31 @@ where
             });
 
             let node_rect = titlebar_rect.union(body_rect).union(bottom_body_rect);
-            let outline = if self.selected {
+            let outline_color = self.graph[self.node_id].user_data.border_color(
+                ui,
+                self.node_id,
+                self.graph,
+                user_state,
+            );
+            let outline = if self.selected || outline_color.is_some() {
+                let (fill, width) = if self.selected {
+                    (Color32::WHITE.lighten(0.8), 1.0)
+                } else {
+                    (
+                        outline_color.unwrap(),
+                        self.graph[self.node_id].user_data.border_width(
+                            ui,
+                            self.node_id,
+                            self.graph,
+                            user_state,
+                        ),
+                    )
+                };
                 Shape::Rect(RectShape {
                     blur_width: 0.0,
-                    rect: node_rect.expand(1.0 * pan_zoom.zoom),
+                    rect: node_rect.expand(width.max(0.0) * pan_zoom.zoom),
                     corner_radius,
-                    fill: Color32::WHITE.lighten(0.8),
+                    fill,
                     stroke: Stroke::NONE,
                     stroke_kind: StrokeKind::Inside,
                     round_to_pixels: None,

--- a/egui-graph-edit/src/traits.rs
+++ b/egui-graph-edit/src/traits.rs
@@ -158,6 +158,30 @@ where
         None
     }
 
+    /// Set an outer border color for the node.
+    /// If the return value is None, no custom border is drawn.
+    fn border_color(
+        &self,
+        _ui: &egui::Ui,
+        _node_id: NodeId,
+        _graph: &Graph<Self, Self::DataType, Self::ValueType>,
+        _user_state: &mut Self::UserState,
+    ) -> Option<egui::Color32> {
+        None
+    }
+
+    /// Set the width of a custom outer border.
+    /// This is only used when `border_color` returns `Some`.
+    fn border_width(
+        &self,
+        _ui: &egui::Ui,
+        _node_id: NodeId,
+        _graph: &Graph<Self, Self::DataType, Self::ValueType>,
+        _user_state: &mut Self::UserState,
+    ) -> f32 {
+        2.0
+    }
+
     /// Separator to put between elements in the node.
     ///
     /// Invoked between inputs, outputs and bottom UI. Useful for


### PR DESCRIPTION

Allows the crate consumer to specify a custom border of any width and color.

<img width="312" height="218" alt="border" src="https://github.com/user-attachments/assets/72258e41-89da-4d40-a186-bd7bba39d74d" />